### PR TITLE
even more fixes to the BCFtools var-caller

### DIFF
--- a/bin/Dantools.pl
+++ b/bin/Dantools.pl
@@ -187,7 +187,7 @@ if ($method eq 'pseudogen') {
                              scoremin => "$scoremin"
         );
 } elsif ("$method" eq 'fragment') {
-    my $lengths = '200,10000';
+    my $lengths = '200,1000';
     my $overlap = 75;
     my $min_length = 20;
     my $output = 'NO_OUTPUT_PROVIDED';
@@ -197,7 +197,8 @@ if ($method eq 'pseudogen') {
 
     GetOptions(
         "lengths|l=s" => \$lengths,
-        "output|o=s" => \$output,
+        "overlap|o=s" => \$overlap,
+        "output=s" => \$output,
         "log=s" => \$log,
         "threads|t=i" => \$threads,
         "help|h" => \$help

--- a/helpdocs/fragment.help
+++ b/helpdocs/fragment.help
@@ -3,8 +3,10 @@ Fragment an input FASTA file into small subsequences
 
 Options:
   -l, --lengths      A comma-separated string of desired fragment
-                     lengths (default: 200,10000)
-  -o, --output       A file to output the fragmented FASTA to
+                     lengths (default: 200,1000)
+  -o, --overlap      Integer indicating percent between adjacent
+                     subsequence fragments (default: 75)
+  --output           A file to output the fragmented FASTA to
   --log              File to write log information to (default:
                      fragment_log.txt)
   -t, --threads      Number of threads to use in parallel

--- a/helpdocs/pseudogen.help
+++ b/helpdocs/pseudogen.help
@@ -11,7 +11,7 @@ Required options:
   -2, --reads-2   mate 2s of paired end .fastq reads
 
 Optional inputs:
-  --fai           a .fasta.fai index file for fasta sources
+  --fai           a .fasta.fai index file for the base fasta
   --base-idx      the path and base name for hisat2 indexes
 
 Output options:
@@ -27,12 +27,12 @@ Fragmentation options (only with FASTA inputs):
   --no-fragment   do not fragment input FASTA file
   --min-length    minimum base length of fragment to be used (default: 20)
   --overlap       integer indicating percent overlap of adjacent fragments
-                  (default: 90)
+                  (default: 75)
 
 Alignment/Variant options:
   --score-min     the input to the HISAT2 score-min function, which governs
-                  minimum the
-                  alignment score for a successful alignment (default: L,0,-1.0)
+                  the minimum alignment score for a successful alignment
+		  (default: L,0,-1.0)
   --var-fraction  the fraction of alleles that must agree to call a variant
                   (default: 0.501)
   --var-depth     minimum number of alignments that need to agree with

--- a/script/aligner.sh
+++ b/script/aligner.sh
@@ -154,9 +154,9 @@ if [ "$variant_caller" == 'freebayes' ]; then
     freebayes-parallel it"$it"/freebayes_regions.tmp "$threads" -f "$base" --min-alternate-fraction "$var_fraction" --min-alternate-count "$var_depth" it"$it"/sorted.bam > it"$it"/variants.vcf
     rm it"$it"/freebayes_regions.tmp
 elif [ "$variant_caller" == 'bcftools' ]; then
-    bcftools mpileup it"$it"/sorted.bam -a FORMAT/AD,FORMAT/DP --threads "$threads" -d 250 -f "$base" it"$it"/sorted.bam |
-        bcftools call -O v -m -v --threads 8 --ploidy 2 |
-        bcftools filter --threads "$threads" -i "FORMAT/AD[0:1] >= ${var_depth} && (FORMAT/AD[0:1] / (FORMAT/AD[0:0] + FORMAT/AD[0:1])) >= ${var_fraction}" > it"$it"/variants.vcf
+    bcftools mpileup -a FORMAT/AD,FORMAT/DP -d 250 -f "$base" it"$it"/sorted.bam |
+        bcftools call -O v -m -v --ploidy 2 |
+        bcftools filter -i "FORMAT/AD[0:1] >= ${var_depth} && (FORMAT/AD[0:1] / (FORMAT/AD[0:0] + FORMAT/AD[0:1])) >= ${var_fraction}" > it"$it"/variants.vcf
 fi
 
 bcftools view -O bcf -o it"$it"/variants.bcf it"$it"/variants.vcf


### PR DESCRIPTION
Yes, even more fixes to the BCFtools variant caller when using dantools pseudogen --var-caller bcftools. Also corrected the dantools fragment function to correctly accept fragment overlap as a parameter. Helpdocs were adjusted accordingly